### PR TITLE
all fetch tests passing with trailing forward slash

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@
 A repo for testing fetch and http implementations.  For some reason, it seems _query strings_ aren't behaving as expected with native **fetch** / **node-fetch** as with raw HTTP.
 
 Seeing it in both these projects
-- https://github.com/AnalogStudiosRI/www.analogstudios.net/issues/81
-- https://github.com/AnalogStudiosRI/www.tuesdaystunes.tv/blob/main/src/pages/index.js#L11
+1. https://github.com/AnalogStudiosRI/www.analogstudios.net/issues/81
+    - fixed in userland by [appending a `/` slash](https://github.com/AnalogStudiosRI/www.analogstudios.net/pull/82)
+1. https://github.com/AnalogStudiosRI/www.tuesdaystunes.tv/blob/main/src/pages/index.js#L11
+    - turned out to be an [incorrect implementation false positive](https://github.com/AnalogStudiosRI/www.tuesdaystunes.tv/pull/90)
 
 ## Setup
 

--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,5 @@
 # constants
-export ENDPOINT='https://www.analogstudios.net/api/albums';
+export ENDPOINT='https://www.analogstudios.net/api/albums/';
 export EXPECTED=1;
 
 # test native fetch


### PR DESCRIPTION
and just like that, adding a `/` made all the tests pass?  😳 
```sh
owenbuckley@Owens-MBP-2 fetch-tests % sh test.sh
(node:25866) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
[fetch] Request => https://www.analogstudios.net/api/albums/?artistId=1
[fetch] Response Length (actual) => 1
[fetch] Response Length (expected) => 1
PASS
===============================================
[nodeFetch] Request => https://www.analogstudios.net/api/albums/?artistId=1
[nodeFetch] Response Length (actual) => 1
[nodeFetch] Response Length (expected) => 1
PASS
===============================================
[https] Request => https://www.analogstudios.net/api/albums/?artistId=1
[https] Response Length (actual) => 1
[https] Response Length (expected) => 1
PASS
===============================================
[request] Request => https://www.analogstudios.net/api/albums/?artistId=1
[request] Response Length (actual) => 1
[request] Response Length (expected) => 1
PASS
===============================================
```

----

Updated Conclusions
- https://github.com/AnalogStudiosRI/www.analogstudios.net/pull/82
- https://github.com/AnalogStudiosRI/www.tuesdaystunes.tv/pull/90